### PR TITLE
Remove the first part of the string if needed without using ltrim

### DIFF
--- a/class-wp-sw-manager.php
+++ b/class-wp-sw-manager.php
@@ -133,10 +133,11 @@ if (!class_exists('WP_SW_Manager')) {
         public function enqueue_registrar() {
             $url = $this->router->route_url(self::SW_REGISTRAR_SCRIPT_URL);
             $site_url = site_url('', 'relative');
+            $relative_to_root_url = $url;
             if (substr($url, 0, strlen($site_url)) === $site_url) {
-              $url = substr($url, strlen($site_url));
+              $relative_to_root_url = substr($url, strlen($site_url));
             }
-            wp_enqueue_script(self::SW_REGISTRAR_SCRIPT, $url);
+            wp_enqueue_script(self::SW_REGISTRAR_SCRIPT, $relative_to_root_url);
         }
 
         private function add_new_sw($scope) {

--- a/class-wp-sw-manager.php
+++ b/class-wp-sw-manager.php
@@ -131,9 +131,12 @@ if (!class_exists('WP_SW_Manager')) {
         }
 
         public function enqueue_registrar() {
-            $real_absolute_url = $this->router->route_url(self::SW_REGISTRAR_SCRIPT_URL);
-            $relative_to_root_url = ltrim($real_absolute_url, site_url('', 'relative'));
-            wp_enqueue_script(self::SW_REGISTRAR_SCRIPT, $relative_to_root_url);
+            $url = $this->router->route_url(self::SW_REGISTRAR_SCRIPT_URL);
+            $site_url = site_url('', 'relative');
+            if (substr($url, 0, strlen($site_url)) === $site_url) {
+              $url = substr($url, strlen($site_url));
+            }
+            wp_enqueue_script(self::SW_REGISTRAR_SCRIPT, $url);
         }
 
         private function add_new_sw($scope) {


### PR DESCRIPTION
I was writing some similar code and noticed a problem.

`site_url('', 'relative')` was `/wordpress`.
The `$real_absolute_url` in my case was `/wordpress/wp-admin/...`.

This code caused the resulting URL to be: `/-admin/...`.
