### PR TITLE
Don't use arrow functions to avoid problems with Safari

### DIFF
--- a/lib/js/sw-registrar.js
+++ b/lib/js/sw-registrar.js
@@ -8,7 +8,7 @@
 
   if ('serviceWorker' in navigator) {
     var enabledSw = $enabledSw;
-    enabledSw.forEach(entry => {
+    enabledSw.forEach(function(entry) {
       var scope = entry.scope;
       var swUrl = entry.url;
       global.$swRegistrations[scope] = navigator.serviceWorker.register(swUrl, { scope: scope });


### PR DESCRIPTION
Fixes #10.
